### PR TITLE
Change potting to be more consistent with vanilla

### DIFF
--- a/src/main/java/com/bagel/buzzierbees/common/blocks/CompatFlowerPotBlock.java
+++ b/src/main/java/com/bagel/buzzierbees/common/blocks/CompatFlowerPotBlock.java
@@ -36,6 +36,7 @@ public class CompatFlowerPotBlock extends Block {
 		if (player.getHeldItem(handIn).getItem() == Blocks.AIR.asItem()) {
 			player.setHeldItem(handIn, new ItemStack(this.flower.get().asItem()));
 			worldIn.setBlockState(pos, Blocks.FLOWER_POT.getDefaultState());
+			player.swingArm(handIn);
 		}
 		return ActionResultType.CONSUME;
 	}

--- a/src/main/java/com/bagel/buzzierbees/common/blocks/HangingFlowerPotBlock.java
+++ b/src/main/java/com/bagel/buzzierbees/common/blocks/HangingFlowerPotBlock.java
@@ -48,6 +48,7 @@ public class HangingFlowerPotBlock extends Block {
 		} else {
 			if (player.getHeldItem(handIn).getItem() == Blocks.AIR.asItem()) {
 				player.setHeldItem(handIn, new ItemStack(this.flower.get().asItem()));
+				player.swingArm(handIn);
 				worldIn.setBlockState(pos, BBBlocks.HANGING_FLOWER_POT.get().getDefaultState());
 			}
 			return ActionResultType.CONSUME;

--- a/src/main/java/com/bagel/buzzierbees/core/registry/BBEvents.java
+++ b/src/main/java/com/bagel/buzzierbees/core/registry/BBEvents.java
@@ -69,9 +69,9 @@ public class BBEvents {
 		ResourceLocation pot = new ResourceLocation(("buzzierbees:potted_" + item.getItem().getRegistryName().getPath()));
 		if (world.getBlockState(pos).getBlock() == Blocks.FLOWER_POT && ForgeRegistries.BLOCKS.containsKey(pot) && item.getItem().isIn(BBTags.MODDED_POTTABLES)) {
 			world.setBlockState(pos, ForgeRegistries.BLOCKS.getValue(pot).getDefaultState());
-			event.getPlayer().swingArm(event.getHand());
+			player.swingArm(event.getHand());
 			player.addStat(Stats.POT_FLOWER);
-			if (!event.getPlayer().abilities.isCreativeMode) item.shrink(1);
+			if (!player.abilities.isCreativeMode) item.shrink(1);
 		}
 	}
 	    

--- a/src/main/java/com/bagel/buzzierbees/core/registry/BBEvents.java
+++ b/src/main/java/com/bagel/buzzierbees/core/registry/BBEvents.java
@@ -65,10 +65,12 @@ public class BBEvents {
 		BlockPos pos = event.getPos();
 		ItemStack item = event.getItemStack();
 		World world = event.getWorld();
+		Player player = event.getPlayer();
 		ResourceLocation pot = new ResourceLocation(("buzzierbees:potted_" + item.getItem().getRegistryName().getPath()));
 		if (world.getBlockState(pos).getBlock() == Blocks.FLOWER_POT && ForgeRegistries.BLOCKS.containsKey(pot) && item.getItem().isIn(BBTags.MODDED_POTTABLES)) {
 			world.setBlockState(pos, ForgeRegistries.BLOCKS.getValue(pot).getDefaultState());
 			event.getPlayer().swingArm(event.getHand());
+			player.addStat(Stats.POT_FLOWER);
 			if (!event.getPlayer().abilities.isCreativeMode) item.shrink(1);
 		}
 	}


### PR DESCRIPTION
The vanilla potting method gives the player a POT_FLOWER stat, and swings their arm when taking an item out, which doesn't happen for buzzier bees' compat and hanging flower pot blocks. I added this functionality in S&R and thought it would be good to have here for consistency.