### PR TITLE
Compatibility improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ modName=Buzzier Bees
 modId=buzzier_bees
 modVersion=3.0.0
 
-abnormalsCore=3147409
+abnormalsCore=3157757

--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBCompat.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBCompat.java
@@ -64,7 +64,7 @@ public class BBCompat {
 				return null;
 			},
 			EntityType.ENDERMITE, (Entity entity) -> {
-				if (entity instanceof SilverfishEntity) {
+				if (entity instanceof EndermiteEntity) {
 					ItemStack bottle = new ItemStack(BBItems.BOTTLE_OF_ENDERMITE.get());
 					if (entity.hasCustomName()) {
 						bottle.setDisplayName(entity.getCustomName());
@@ -124,7 +124,7 @@ public class BBCompat {
 		DataUtil.registerAlternativeDispenseBehavior(Items.GLASS_BOTTLE, (source, stack) -> !BlockUtil.getEntitiesAtOffsetPos(source, CreatureEntity.class, e -> ENTITY_TYPE_TO_BOTTLE_MAP.containsKey(e.getType())).isEmpty(), new DefaultDispenseItemBehavior() {
 			@Override
 			protected ItemStack dispenseStack(IBlockSource source, ItemStack stack) {
-				Entity entity = BlockUtil.getEntitiesAtOffsetPos(source, CreatureEntity.class, e -> ENTITY_TYPE_TO_BOTTLE_MAP.containsKey(e.getType())).get(0);
+				Entity entity = BlockUtil.getEntitiesAtOffsetPos(source, Entity.class, e -> ENTITY_TYPE_TO_BOTTLE_MAP.containsKey(e.getType())).get(0);
 				ItemStack bottled = ENTITY_TYPE_TO_BOTTLE_MAP.get(entity.getType()).apply(entity);
 				stack.shrink(1);
 				if (stack.isEmpty()) {

--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
@@ -97,20 +97,22 @@ public class BBEvents {
 			PlayerEntity player = event.getPlayer();
 			Hand hand = event.getHand();
 
-			ItemStack bottle = BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.get(targetType).apply(target);
+			if (BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.containsKey(targetType)) {
+				ItemStack bottle = BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.get(targetType).apply(target);
 
-			if (bottle != null && target.isAlive()) {
-				if (item == Items.GLASS_BOTTLE) {
-					itemstack.shrink(1);
-					event.getWorld().playSound(null, event.getPos(), SoundEvents.ITEM_BOTTLE_FILL_DRAGONBREATH, SoundCategory.NEUTRAL, 1.0F, 1.0F);
-					player.addStat(Stats.ITEM_USED.get(event.getItemStack().getItem()));
-					event.getTarget().remove();
-					if (itemstack.isEmpty()) {
-						player.setHeldItem(hand, bottle);
-					} else if (!player.inventory.addItemStackToInventory(bottle)) {
-						player.dropItem(bottle, false);
+				if (bottle != null && target.isAlive()) {
+					if (item == Items.GLASS_BOTTLE) {
+						itemstack.shrink(1);
+						event.getWorld().playSound(null, event.getPos(), SoundEvents.ITEM_BOTTLE_FILL_DRAGONBREATH, SoundCategory.NEUTRAL, 1.0F, 1.0F);
+						player.addStat(Stats.ITEM_USED.get(event.getItemStack().getItem()));
+						event.getTarget().remove();
+						if (itemstack.isEmpty()) {
+							player.setHeldItem(hand, bottle);
+						} else if (!player.inventory.addItemStackToInventory(bottle)) {
+							player.dropItem(bottle, false);
+						}
+						player.swingArm(hand);
 					}
-					player.swingArm(hand);
 				}
 			}
 		}

--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
@@ -4,7 +4,6 @@ import com.minecraftabnormals.buzzier_bees.common.entities.MoobloomEntity;
 import com.minecraftabnormals.buzzier_bees.core.BBConfig;
 import com.minecraftabnormals.buzzier_bees.core.BuzzierBees;
 import com.minecraftabnormals.buzzier_bees.core.registry.BBEffects;
-import com.minecraftabnormals.buzzier_bees.core.registry.BBItems;
 import net.minecraft.block.Block;
 import net.minecraft.block.FlowerBlock;
 import net.minecraft.block.IGrowable;
@@ -15,20 +14,17 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.ai.goal.NearestAttackableTargetGoal;
 import net.minecraft.entity.monster.PhantomEntity;
-import net.minecraft.entity.passive.BeeEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.BoneMealItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.stats.Stats;
 import net.minecraft.util.Hand;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
@@ -96,58 +92,28 @@ public class BBEvents {
 			ItemStack itemstack = event.getPlayer().getHeldItem(event.getHand());
 			Item item = itemstack.getItem();
 
-			Item bottle = null;
-			boolean successful = false;
-
 			Entity target = event.getTarget();
 			EntityType<?> targetType = target.getType();
 			PlayerEntity player = event.getPlayer();
 			Hand hand = event.getHand();
 
-			if (targetType == EntityType.SILVERFISH) {
-				bottle = BBItems.BOTTLE_OF_SILVERFISH.get();
-				successful = true;
-			}
-			if (targetType == EntityType.ENDERMITE) {
-				bottle = BBItems.BOTTLE_OF_ENDERMITE.get();
-				successful = true;
-			}
-			if (targetType == EntityType.BEE) {
-				bottle = BBItems.BOTTLE_OF_BEE.get();
-				successful = true;
-			}
-			ItemStack bottleItem = new ItemStack(bottle);
+			ItemStack bottle = BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.get(targetType).apply(target);
 
-			if (targetType == EntityType.BEE) {
-				BeeEntity bee = (BeeEntity) target;
-				CompoundNBT tag = bottleItem.getOrCreateTag();
-				tag.putBoolean("HasNectar", bee.hasNectar());
-				tag.putBoolean("HasStung", bee.hasStung());
-				tag.putInt("AngerTime", bee.getAngerTime());
-				if (bee.getAngerTarget() != null) tag.putUniqueId("AngryAt", bee.getAngerTarget());
-				tag.putInt("Age", bee.getGrowingAge());
-				tag.putFloat("Health", bee.getHealth());
-			}
-
-			if (target.hasCustomName()) {
-				ITextComponent name = target.getCustomName();
-				bottleItem = bottleItem.setDisplayName(name);
-			}
-
-			if (successful && ((MobEntity) target).isAlive()) {
+			if (bottle != null && target.isAlive()) {
 				if (item == Items.GLASS_BOTTLE) {
 					itemstack.shrink(1);
-					event.getWorld().playSound(player, event.getPos(), SoundEvents.ITEM_BOTTLE_FILL_DRAGONBREATH, SoundCategory.NEUTRAL, 1.0F, 1.0F);
+					event.getWorld().playSound(null, event.getPos(), SoundEvents.ITEM_BOTTLE_FILL_DRAGONBREATH, SoundCategory.NEUTRAL, 1.0F, 1.0F);
 					player.addStat(Stats.ITEM_USED.get(event.getItemStack().getItem()));
 					event.getTarget().remove();
 					if (itemstack.isEmpty()) {
-						player.setHeldItem(hand, bottleItem);
-					} else if (!player.inventory.addItemStackToInventory(bottleItem)) {
-						player.dropItem(bottleItem, false);
+						player.setHeldItem(hand, bottle);
+					} else if (!player.inventory.addItemStackToInventory(bottle)) {
+						player.dropItem(bottle, false);
 					}
 					player.swingArm(hand);
 				}
 			}
 		}
 	}
+
 }

--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
@@ -99,7 +99,6 @@ public class BBEvents {
 
 			if (BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.containsKey(targetType)) {
 				ItemStack bottle = BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.get(targetType).apply(target);
-
 				if (bottle != null && target.isAlive()) {
 					if (item == Items.GLASS_BOTTLE) {
 						itemstack.shrink(1);

--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/other/BBEvents.java
@@ -97,24 +97,21 @@ public class BBEvents {
 			PlayerEntity player = event.getPlayer();
 			Hand hand = event.getHand();
 
-			if (BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.containsKey(targetType)) {
+			if (item == Items.GLASS_BOTTLE && target.isAlive() && BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.containsKey(targetType)) {
 				ItemStack bottle = BBCompat.ENTITY_TYPE_TO_BOTTLE_MAP.get(targetType).apply(target);
-				if (bottle != null && target.isAlive()) {
-					if (item == Items.GLASS_BOTTLE) {
-						itemstack.shrink(1);
-						event.getWorld().playSound(null, event.getPos(), SoundEvents.ITEM_BOTTLE_FILL_DRAGONBREATH, SoundCategory.NEUTRAL, 1.0F, 1.0F);
-						player.addStat(Stats.ITEM_USED.get(event.getItemStack().getItem()));
-						event.getTarget().remove();
-						if (itemstack.isEmpty()) {
-							player.setHeldItem(hand, bottle);
-						} else if (!player.inventory.addItemStackToInventory(bottle)) {
-							player.dropItem(bottle, false);
-						}
-						player.swingArm(hand);
+				if (bottle != null) {
+					itemstack.shrink(1);
+					event.getWorld().playSound(null, event.getPos(), SoundEvents.ITEM_BOTTLE_FILL_DRAGONBREATH, SoundCategory.NEUTRAL, 1.0F, 1.0F);
+					player.addStat(Stats.ITEM_USED.get(item));
+					event.getTarget().remove();
+					if (itemstack.isEmpty()) {
+						player.setHeldItem(hand, bottle);
+					} else if (!player.inventory.addItemStackToInventory(bottle)) {
+						player.dropItem(bottle, false);
 					}
+					player.swingArm(hand);
 				}
 			}
 		}
 	}
-
 }

--- a/src/main/java/com/minecraftabnormals/buzzier_bees/core/registry/BBVillagers.java
+++ b/src/main/java/com/minecraftabnormals/buzzier_bees/core/registry/BBVillagers.java
@@ -2,23 +2,23 @@ package com.minecraftabnormals.buzzier_bees.core.registry;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.buzzier_bees.core.BuzzierBees;
-import com.mojang.datafixers.util.Either;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.entity.ai.brain.task.GiveHeroGiftsTask;
 import net.minecraft.entity.merchant.villager.VillagerProfession;
 import net.minecraft.item.Items;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvents;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.util.registry.WorldGenRegistries;
 import net.minecraft.village.PointOfInterestType;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPattern;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPatternRegistry;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPiece;
-import net.minecraft.world.gen.feature.jigsaw.LegacySingleJigsawPiece;
-import net.minecraft.world.gen.feature.structure.*;
-import net.minecraft.world.gen.feature.template.ProcessorLists;
+import net.minecraft.world.gen.feature.structure.DesertVillagePools;
+import net.minecraft.world.gen.feature.structure.PlainsVillagePools;
+import net.minecraft.world.gen.feature.structure.SavannaVillagePools;
+import net.minecraft.world.gen.feature.structure.SnowyVillagePools;
+import net.minecraft.world.gen.feature.structure.TaigaVillagePools;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
@@ -26,9 +26,6 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
 public class BBVillagers {
@@ -66,16 +63,6 @@ public class BBVillagers {
 		TaigaVillagePools.init();
 
 		for (String biome : new String[]{"plains", "snowy", "savanna", "desert", "taiga"})
-			addToPool(new ResourceLocation("village/" + biome + "/houses"), new ResourceLocation(BuzzierBees.MOD_ID, "village/apiarist_house_" + biome + "_1"), 1);
-	}
-
-	private static void addToPool(ResourceLocation pool, ResourceLocation toAdd, int weight) {
-		JigsawPattern old = WorldGenRegistries.JIGSAW_POOL.getOrDefault(pool);
-		List<JigsawPiece> shuffled = old.getShuffledPieces(new Random());
-		List<Pair<JigsawPiece, Integer>> newPieces = new ArrayList<>();
-		for (JigsawPiece p : shuffled) newPieces.add(new Pair<>(p, 1));
-		newPieces.add(Pair.of(new LegacySingleJigsawPiece(Either.left(toAdd), () -> ProcessorLists.field_244101_a, JigsawPattern.PlacementBehaviour.RIGID), weight));
-		ResourceLocation name = old.getName();
-		Registry.register(WorldGenRegistries.JIGSAW_POOL, pool, new JigsawPattern(pool, name, newPieces));
+			DataUtil.addToJigsawPattern(new ResourceLocation("village/" + biome + "/houses"), JigsawPiece.func_242849_a(BuzzierBees.MOD_ID + ":village/apiarist_house_" + biome + "_1").apply(JigsawPattern.PlacementBehaviour.RIGID), 1);
 	}
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -31,6 +31,6 @@ license = "https://github.com/team-abnormals/buzzier-bees/blob/main/LICENSE.txt"
 [[dependencies.buzzier_bees]]
     modId = "abnormals_core"
     mandatory = true
-    versionRange = "[3.0.4,)"
+    versionRange = "[3.0.6,)"
     ordering = "AFTER"
     side = "BOTH"


### PR DESCRIPTION
This PR adds dispenser behaviors for bottling mobs and lighting candles, as well as a map used to get bottle item stacks from entity types, which saves having to write out special cases twice and could be changed in the future to allow other mods adding bottled mobs. It also deletes `addToPool` and uses AC's `addToJigsawPattern` instead, which retains the weights from the original list. However, now the other elements in the housing pool aren't being set to 1, the apiarist house is rarer. Should its weight be increased?